### PR TITLE
fix: minor typo fix on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ make sbom   # SBOM generation (SPDX JSON)
 
 - [`Dockerfile.bad`](https://github.com/cloudnativeciso/secure-by-default-starter/blob/demo-bad-examples-v1/examples/Dockerfile.bad)
 - [`pod-insecure.yaml`](https://github.com/cloudnativeciso/secure-by-default-starter/blob/demo-bad-examples-v1/examples/pod-insecure.yaml)
-- [`main.bad.tf`](https://github.com/cloudnativeciso/secure-by-default-starter/blob/demo-bad-examples-v3/examples/terraform/main.bad.tf)
+- [`main.bad.tf`](https://github.com/cloudnativeciso/secure-by-default-starter/blob/demo-bad-examples-v2/examples/terraform/main.bad.tf)
 
 ---
 


### PR DESCRIPTION
## What
- typo fix

## Why
- 

## How tested
- [ ] Local: `pre-commit` passes
- [ ] CI: Security workflow green on this branch
- [ ] Screenshots / logs (optional):
  - 

## Risk & rollout
- [ ] Backward compatible
- [x] Docs updated (README / docs/)
- [ ] No secrets or sensitive data introduced

## Type
- [x] feat
- [ ] fix
- [ ] docs
- [ ] chore/ci
- [ ] test

---

### Guardrails checklist (automated)
- Pre-commit: **Gitleaks** blocks secrets locally
- CI: **Trivy** uploads SARIF to Code Scanning
- CI: **SBOM** artifact (spdx) published on each run